### PR TITLE
feat: add GitHub Copilot CLI provider

### DIFF
--- a/GlobalTranslator.xcodeproj/project.pbxproj
+++ b/GlobalTranslator.xcodeproj/project.pbxproj
@@ -20,11 +20,13 @@
 		76A9300886AEEE2EE470B2C2 /* AppSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BEB1491F77B533B2E1677E /* AppSettingsStore.swift */; };
 		8754A8EB8551AF847030C060 /* TranslationJob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78929B3D80C28EA9384E4A6C /* TranslationJob.swift */; };
 		8D884E373B7222FF5A6ECAF7 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0EE1EAE0DC5E65BC023DFFE /* MenuBarController.swift */; };
+		92D7E0E945EB971936B8CB9E /* CopilotCLIExecutableLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE4A1F1547B29FFB40E0E10 /* CopilotCLIExecutableLocatorTests.swift */; };
 		965204E177A5BF410B69269A /* TargetLanguageResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C5D83BA30DEEFB413F136C /* TargetLanguageResolver.swift */; };
 		A147B5173C07146D42F6E6FD /* HotkeyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B225BE2F946203083A19D171 /* HotkeyService.swift */; };
 		A29FE958BDCAAED868A45789 /* ProviderRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B119CE831FEC1A85606A88C0 /* ProviderRegistry.swift */; };
 		A554068842D42E3B14BA8154 /* WritebackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A957A5C64CF3118DD0ABA9 /* WritebackService.swift */; };
 		AB451B8742888333DA2F69F1 /* DeepLProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C8D12B5757FB7D85A3CD100 /* DeepLProvider.swift */; };
+		B0A547D7590A8ED5CA275E59 /* CopilotCLIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA0B49A8C388D963AEBFCB /* CopilotCLIProviderTests.swift */; };
 		B2E00C8451210282B12C7A17 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F716189CE25FB51852A59D08 /* SettingsView.swift */; };
 		BDF210248CDA4206E23F28D4 /* TargetLanguageResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9ECA8D5DAA8AA5E76C72816 /* TargetLanguageResolverTests.swift */; };
 		BE9A309BE2815A314626CCE1 /* WritebackServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614D715D8460523B68AB47FA /* WritebackServiceTests.swift */; };
@@ -35,6 +37,7 @@
 		D4403A355424F69D2456E7E8 /* TranslationQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67A01302E7A982B05998C29 /* TranslationQueueTests.swift */; };
 		DCE07BD9C69A3C7879CA6824 /* OpenAIProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312E6A2580519C676B71E3F3 /* OpenAIProviderTests.swift */; };
 		DF3DC88B81FEB8D4B8C31C0B /* CapturedSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 389858F5E8817C49D954E0CA /* CapturedSelection.swift */; };
+		EB130A5E2D0E9FE41A4F2CAD /* CopilotCLIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FB25B1D33EF82D9B395407 /* CopilotCLIProvider.swift */; };
 		ED742F3BEC4FFB4F7EEEF24E /* TranslationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF42AB48F0EA6C9D838379B5 /* TranslationQueue.swift */; };
 		F2907B2547D9D25A9C8FE173 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67700474A259DFAD8A829C1 /* OnboardingView.swift */; };
 		F32CA4E0F75E01BC2ACE6EE6 /* AppSettingsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA31DD2683ACAE7B48202EB /* AppSettingsStoreTests.swift */; };
@@ -63,9 +66,11 @@
 		2F6D2A2C9837397B99D99187 /* ProviderRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderRegistryTests.swift; sourceTree = "<group>"; };
 		312E6A2580519C676B71E3F3 /* OpenAIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIProviderTests.swift; sourceTree = "<group>"; };
 		389858F5E8817C49D954E0CA /* CapturedSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturedSelection.swift; sourceTree = "<group>"; };
+		40AA0B49A8C388D963AEBFCB /* CopilotCLIProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotCLIProviderTests.swift; sourceTree = "<group>"; };
 		42A957A5C64CF3118DD0ABA9 /* WritebackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritebackService.swift; sourceTree = "<group>"; };
 		503D2E4F56460583B222A175 /* ContractTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractTestSupport.swift; sourceTree = "<group>"; };
 		58EB467DC1E85C745F15CD0A /* AccessibilityCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityCaptureService.swift; sourceTree = "<group>"; };
+		5DE4A1F1547B29FFB40E0E10 /* CopilotCLIExecutableLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotCLIExecutableLocatorTests.swift; sourceTree = "<group>"; };
 		614D715D8460523B68AB47FA /* WritebackServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritebackServiceTests.swift; sourceTree = "<group>"; };
 		61D49BD769F2F9DF4DFE4E8B /* TranslationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationProvider.swift; sourceTree = "<group>"; };
 		68BEB1491F77B533B2E1677E /* AppSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStore.swift; sourceTree = "<group>"; };
@@ -76,6 +81,7 @@
 		82AB3894C4567D630D3CC9AE /* CredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialStore.swift; sourceTree = "<group>"; };
 		88C5D83BA30DEEFB413F136C /* TargetLanguageResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetLanguageResolver.swift; sourceTree = "<group>"; };
 		9704C253C0FE7DCD29EDADFA /* GlobalTranslator.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GlobalTranslator.entitlements; sourceTree = "<group>"; };
+		99FB25B1D33EF82D9B395407 /* CopilotCLIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopilotCLIProvider.swift; sourceTree = "<group>"; };
 		A0F8F9F49BBFA6A76FF87157 /* FixtureEditorApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixtureEditorApp.swift; sourceTree = "<group>"; };
 		A67A01302E7A982B05998C29 /* TranslationQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationQueueTests.swift; sourceTree = "<group>"; };
 		ABA31DD2683ACAE7B48202EB /* AppSettingsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsStoreTests.swift; sourceTree = "<group>"; };
@@ -99,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				ABA31DD2683ACAE7B48202EB /* AppSettingsStoreTests.swift */,
+				5DE4A1F1547B29FFB40E0E10 /* CopilotCLIExecutableLocatorTests.swift */,
 				2F6D2A2C9837397B99D99187 /* ProviderRegistryTests.swift */,
 				D9ECA8D5DAA8AA5E76C72816 /* TargetLanguageResolverTests.swift */,
 				A67A01302E7A982B05998C29 /* TranslationQueueTests.swift */,
@@ -167,6 +174,14 @@
 			path = DeepL;
 			sourceTree = "<group>";
 		};
+		6AD65BF073FB434621D27642 /* Copilot */ = {
+			isa = PBXGroup;
+			children = (
+				99FB25B1D33EF82D9B395407 /* CopilotCLIProvider.swift */,
+			);
+			path = Copilot;
+			sourceTree = "<group>";
+		};
 		6BC44A6B5269D627356CC3FB /* Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -208,6 +223,7 @@
 				B119CE831FEC1A85606A88C0 /* ProviderRegistry.swift */,
 				88C5D83BA30DEEFB413F136C /* TargetLanguageResolver.swift */,
 				61D49BD769F2F9DF4DFE4E8B /* TranslationProvider.swift */,
+				6AD65BF073FB434621D27642 /* Copilot */,
 				6325FB3FAF8653B7BD6A060A /* DeepL */,
 				CE36440EE661D51DB7ADFEA3 /* Google */,
 				6D9F5CDD0115C2BD9EBE6ECD /* OpenAI */,
@@ -274,6 +290,7 @@
 			isa = PBXGroup;
 			children = (
 				503D2E4F56460583B222A175 /* ContractTestSupport.swift */,
+				40AA0B49A8C388D963AEBFCB /* CopilotCLIProviderTests.swift */,
 				21C10D601E22C39A2DEA9153 /* DeepLProviderTests.swift */,
 				6AA6984E8C900A91DBE30EF7 /* GoogleCloudTranslationProviderTests.swift */,
 				312E6A2580519C676B71E3F3 /* OpenAIProviderTests.swift */,
@@ -427,6 +444,8 @@
 			files = (
 				F32CA4E0F75E01BC2ACE6EE6 /* AppSettingsStoreTests.swift in Sources */,
 				D139333C9FBC329FA123CF59 /* ContractTestSupport.swift in Sources */,
+				92D7E0E945EB971936B8CB9E /* CopilotCLIExecutableLocatorTests.swift in Sources */,
+				B0A547D7590A8ED5CA275E59 /* CopilotCLIProviderTests.swift in Sources */,
 				614272A079DF1B0C3098921D /* DeepLProviderTests.swift in Sources */,
 				5A43B4DB775439DCB6B1BB65 /* GoogleCloudTranslationProviderTests.swift in Sources */,
 				DCE07BD9C69A3C7879CA6824 /* OpenAIProviderTests.swift in Sources */,
@@ -454,6 +473,7 @@
 				CB1113B077C4B3C83B87493E /* AppSettings.swift in Sources */,
 				76A9300886AEEE2EE470B2C2 /* AppSettingsStore.swift in Sources */,
 				DF3DC88B81FEB8D4B8C31C0B /* CapturedSelection.swift in Sources */,
+				EB130A5E2D0E9FE41A4F2CAD /* CopilotCLIProvider.swift in Sources */,
 				4718CE1DDADACF65146AA6F8 /* CredentialStore.swift in Sources */,
 				AB451B8742888333DA2F69F1 /* DeepLProvider.swift in Sources */,
 				FC273183BC29F23C8C635F83 /* GlobalTranslatorApp.swift in Sources */,

--- a/GlobalTranslator/Features/MenuBar/MenuBarController.swift
+++ b/GlobalTranslator/Features/MenuBar/MenuBarController.swift
@@ -11,6 +11,7 @@ final class MenuBarController: ObservableObject {
     let providerRegistry: ProviderRegistry
 
     private let captureService: AccessibilityCaptureService
+    private let copilotExecutableLocator: any CopilotCLIExecutableLocating
     private let writebackService: WritebackService
     private let notificationCenter: any UserNotificationCentering
     private let hotkeyService: HotkeyService
@@ -22,6 +23,7 @@ final class MenuBarController: ObservableObject {
         credentialStore: CredentialStore = CredentialStore(),
         providerRegistry: ProviderRegistry = ProviderRegistry(),
         captureService: AccessibilityCaptureService = AccessibilityCaptureService(),
+        copilotExecutableLocator: any CopilotCLIExecutableLocating = CopilotCLIExecutableLocator(),
         writebackService: WritebackService = WritebackService(),
         notificationCenter: any UserNotificationCentering = SystemUserNotificationCenter(),
         hotkeyService: HotkeyService = HotkeyService()
@@ -30,6 +32,7 @@ final class MenuBarController: ObservableObject {
         self.credentialStore = credentialStore
         self.providerRegistry = providerRegistry
         self.captureService = captureService
+        self.copilotExecutableLocator = copilotExecutableLocator
         self.writebackService = writebackService
         self.notificationCenter = notificationCenter
         self.hotkeyService = hotkeyService
@@ -55,7 +58,7 @@ final class MenuBarController: ObservableObject {
     }
 
     var requiresOnboarding: Bool {
-        !AccessibilityCaptureService.isTrusted || credentialStore.credential(for: settingsStore.settings.defaultProvider) == nil
+        !AccessibilityCaptureService.isTrusted || !isProviderReady(settingsStore.settings.defaultProvider)
     }
 
     func start() {
@@ -100,8 +103,22 @@ final class MenuBarController: ObservableObject {
         }
     }
 
-    func saveAPIKey(_ apiKey: String) {
-        credentialStore.save(apiKey: apiKey, for: settingsStore.settings.defaultProvider)
+    func saveAPIKey(_ apiKey: String, for providerID: String) {
+        credentialStore.save(apiKey: apiKey, for: providerID)
+    }
+
+    func isProviderReady(_ providerID: String) -> Bool {
+        guard let descriptor = providerRegistry.descriptor(for: providerID) else {
+            return false
+        }
+        if descriptor.requiresStoredCredential {
+            return credentialStore.credential(for: providerID) != nil
+        }
+        if providerID == "copilot" {
+            return copilotExecutableLocator.findExecutable() != nil
+        }
+
+        return true
     }
 
     private func consume(snapshot: TranslationJobSnapshot) {

--- a/GlobalTranslator/Features/Onboarding/OnboardingView.swift
+++ b/GlobalTranslator/Features/Onboarding/OnboardingView.swift
@@ -5,7 +5,40 @@ struct OnboardingView: View {
 
     private var defaultProviderDescriptor: ProviderDescriptor {
         controller.providerRegistry.descriptor(for: controller.settingsStore.settings.defaultProvider)
-            ?? OpenAIProvider().descriptor
+            ?? CopilotCLIProvider().descriptor
+    }
+
+    private var defaultProviderID: String {
+        controller.settingsStore.settings.defaultProvider
+    }
+
+    private var providerSetupTitle: String {
+        defaultProviderDescriptor.requiresStoredCredential ? defaultProviderDescriptor.credentialLabel : "GitHub Copilot CLI"
+    }
+
+    private var providerSetupDetail: String {
+        if defaultProviderDescriptor.requiresStoredCredential {
+            return controller.credentialStore.credential(for: defaultProviderID) == nil ? "Missing" : "Saved"
+        }
+
+        return controller.isProviderReady(defaultProviderID)
+            ? "Detected locally"
+            : "Missing. Install and sign in locally."
+    }
+
+    private var providerSetupButtonTitle: String {
+        defaultProviderDescriptor.requiresStoredCredential ? "Open Settings" : "Open Copilot Docs"
+    }
+
+    private func openProviderSetup() {
+        if defaultProviderDescriptor.requiresStoredCredential {
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            return
+        }
+
+        if let url = URL(string: "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     var body: some View {
@@ -24,12 +57,11 @@ struct OnboardingView: View {
             }
 
             setupRow(
-                title: defaultProviderDescriptor.credentialLabel,
-                detail: controller.credentialStore.credential(for: controller.settingsStore.settings.defaultProvider) == nil ? "Missing" : "Saved",
-                buttonTitle: "Open Settings"
-            ) {
-                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-            }
+                title: providerSetupTitle,
+                detail: providerSetupDetail,
+                buttonTitle: providerSetupButtonTitle,
+                action: openProviderSetup
+            )
 
             setupRow(
                 title: "Hotkey",

--- a/GlobalTranslator/Features/Settings/SettingsView.swift
+++ b/GlobalTranslator/Features/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ struct SettingsView: View {
 
     private var selectedProviderDescriptor: ProviderDescriptor {
         controller.providerRegistry.descriptor(for: selectedProvider)
-            ?? OpenAIProvider().descriptor
+            ?? CopilotCLIProvider().descriptor
     }
 
     var body: some View {
@@ -49,10 +49,21 @@ struct SettingsView: View {
                 }
             }
 
-            Section(selectedProviderDescriptor.credentialLabel) {
-                SecureField(selectedProviderDescriptor.credentialPlaceholder, text: $apiKey)
-                Button("Save \(selectedProviderDescriptor.credentialLabel)") {
-                    controller.saveAPIKey(apiKey)
+            if selectedProviderDescriptor.requiresStoredCredential {
+                Section(selectedProviderDescriptor.credentialLabel) {
+                    SecureField(selectedProviderDescriptor.credentialPlaceholder, text: $apiKey)
+                    Button("Save \(selectedProviderDescriptor.credentialLabel)") {
+                        controller.saveAPIKey(apiKey, for: selectedProvider)
+                    }
+                }
+            } else {
+                Section("Provider Setup") {
+                    Text(
+                        controller.isProviderReady(selectedProvider)
+                            ? "GitHub Copilot CLI was found locally and will use your existing CLI session."
+                            : "Install GitHub Copilot CLI locally and sign in from Terminal before using this provider."
+                    )
+                    .foregroundStyle(.secondary)
                 }
             }
 
@@ -87,7 +98,7 @@ struct SettingsView: View {
     }
 
     private func reloadProviderFields(for providerID: String) {
-        let descriptor = controller.providerRegistry.descriptor(for: providerID) ?? OpenAIProvider().descriptor
+        let descriptor = controller.providerRegistry.descriptor(for: providerID) ?? CopilotCLIProvider().descriptor
         model = controller.settingsStore.settings.preferences(for: providerID).model ?? descriptor.defaultModel ?? ""
         apiKey = controller.credentialStore.apiKey(for: providerID)
     }

--- a/GlobalTranslator/Models/AppSettings.swift
+++ b/GlobalTranslator/Models/AppSettings.swift
@@ -85,7 +85,7 @@ struct AppSettings: Codable, Equatable, Sendable {
     init(
         targetLanguage: String = "English",
         hotkey: HotkeyShortcut = .commandShiftT,
-        defaultProvider: String = "openai",
+        defaultProvider: String = "copilot",
         providerPreferences: [String: ProviderPreferences] = ["openai": .openAIDefault],
         recentJobs: [RecentTranslationJob] = []
     ) {

--- a/GlobalTranslator/Services/Providers/Copilot/CopilotCLIProvider.swift
+++ b/GlobalTranslator/Services/Providers/Copilot/CopilotCLIProvider.swift
@@ -9,7 +9,7 @@ struct CopilotCLIExecutableLocator: CopilotCLIExecutableLocating {
     private let environment: [String: String]
 
     init(
-        fileManager: any FileManaging = FileManager.default,
+        fileManager: any FileManaging = DefaultFileManager(),
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
         self.fileManager = fileManager

--- a/GlobalTranslator/Services/Providers/Copilot/CopilotCLIProvider.swift
+++ b/GlobalTranslator/Services/Providers/Copilot/CopilotCLIProvider.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+protocol CopilotCLIExecutableLocating: Sendable {
+    func findExecutable() -> URL?
+}
+
+struct CopilotCLIExecutableLocator: CopilotCLIExecutableLocating {
+    private let fileManager: any FileManaging
+    private let environment: [String: String]
+
+    init(
+        fileManager: any FileManaging = FileManager.default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        self.fileManager = fileManager
+        self.environment = environment
+    }
+
+    func findExecutable() -> URL? {
+        for path in candidatePaths where fileManager.fileExists(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+
+        return nil
+    }
+
+    private var candidatePaths: [String] {
+        let knownLocations = [
+            "/opt/homebrew/bin/copilot",
+            "/usr/local/bin/copilot",
+        ]
+        let pathEntries = (environment["PATH"] ?? "")
+            .split(separator: ":")
+            .map { String($0) }
+            .filter { !$0.isEmpty }
+            .map { URL(fileURLWithPath: $0).appendingPathComponent("copilot").path }
+
+        return knownLocations + pathEntries
+    }
+}
+
+enum CopilotCLIProviderError: LocalizedError {
+    case executableNotFound
+    case timedOut
+    case emptyOutput
+    case processFailed(String)
+    case workingDirectoryUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .executableNotFound:
+            return "GitHub Copilot CLI was not found. Install `copilot` locally before using this provider."
+        case .timedOut:
+            return "GitHub Copilot CLI timed out before returning a translation."
+        case .emptyOutput:
+            return "GitHub Copilot CLI returned an empty translation."
+        case let .processFailed(message):
+            return "GitHub Copilot CLI failed: \(message)"
+        case .workingDirectoryUnavailable:
+            return "Global Translator could not prepare a neutral working directory for GitHub Copilot CLI."
+        }
+    }
+}
+
+struct CopilotCLIProvider: TranslationProvider {
+    let descriptor = ProviderDescriptor(
+        id: "copilot",
+        displayName: "GitHub Copilot",
+        credentialLabel: "",
+        credentialPlaceholder: "",
+        requiresStoredCredential: false,
+        supportsCustomModel: true,
+        defaultModel: nil
+    )
+
+    private let commandRunner: any CommandRunning
+    private let executableLocator: any CopilotCLIExecutableLocating
+    private let workingDirectory: URL
+    private let timeout: TimeInterval
+
+    init(
+        commandRunner: any CommandRunning = ProcessCommandRunner(),
+        executableLocator: any CopilotCLIExecutableLocating = CopilotCLIExecutableLocator(),
+        workingDirectory: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GlobalTranslator.CopilotCLI", isDirectory: true),
+        timeout: TimeInterval = 45
+    ) {
+        self.commandRunner = commandRunner
+        self.executableLocator = executableLocator
+        self.workingDirectory = workingDirectory
+        self.timeout = timeout
+    }
+
+    func translate(
+        _ request: TranslationRequest,
+        credential: ProviderCredential?,
+        preferences: ProviderPreferences
+    ) async throws -> TranslationResponse {
+        _ = credential
+
+        guard let executableURL = executableLocator.findExecutable() else {
+            throw CopilotCLIProviderError.executableNotFound
+        }
+        do {
+            try FileManager.default.createDirectory(
+                at: workingDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw CopilotCLIProviderError.workingDirectoryUnavailable
+        }
+
+        do {
+            let result = try await commandRunner.run(
+                CommandInvocation(
+                    executableURL: executableURL,
+                    arguments: arguments(for: request, model: preferences.model),
+                    workingDirectoryURL: workingDirectory,
+                    environment: [:],
+                    timeout: timeout
+                )
+            )
+
+            guard result.exitCode == 0 else {
+                let message = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                throw CopilotCLIProviderError.processFailed(
+                    message.isEmpty ? "exit code \(result.exitCode)" : message
+                )
+            }
+
+            let translatedText = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !translatedText.isEmpty else {
+                throw CopilotCLIProviderError.emptyOutput
+            }
+
+            return TranslationResponse(translatedText: translatedText, detectedSourceLanguage: "auto")
+        } catch let error as CommandRunnerError {
+            switch error {
+            case .timedOut:
+                throw CopilotCLIProviderError.timedOut
+            case let .failedToLaunch(message):
+                throw CopilotCLIProviderError.processFailed(message)
+            }
+        }
+    }
+
+    private func arguments(for request: TranslationRequest, model: String?) -> [String] {
+        var arguments = [
+            "-p",
+            prompt(for: request),
+            "-s",
+            "--allow-all-tools",
+            "--excluded-tools", "read", "write", "shell", "url", "memory",
+            "--disable-builtin-mcps",
+            "--no-custom-instructions",
+            "--no-auto-update",
+        ]
+        if let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            arguments.append(contentsOf: ["--model", model])
+        }
+
+        return arguments
+    }
+
+    private func prompt(for request: TranslationRequest) -> String {
+        """
+        Translate the following text into \(request.targetLanguage).
+        Preserve line breaks and plain-text structure.
+        Return only the translated text.
+        Do not explain anything.
+        Do not wrap the answer in code fences.
+        Do not add prefixes or suffixes.
+        Do not use tools.
+
+        \(request.text)
+        """
+    }
+}

--- a/GlobalTranslator/Services/Providers/DeepL/DeepLProvider.swift
+++ b/GlobalTranslator/Services/Providers/DeepL/DeepLProvider.swift
@@ -6,6 +6,7 @@ struct DeepLProvider: TranslationProvider {
         displayName: "DeepL",
         credentialLabel: "API key",
         credentialPlaceholder: "DeepL API key",
+        requiresStoredCredential: true,
         supportsCustomModel: false,
         defaultModel: nil
     )
@@ -29,9 +30,12 @@ struct DeepLProvider: TranslationProvider {
 
     func translate(
         _ request: TranslationRequest,
-        credential: ProviderCredential,
+        credential: ProviderCredential?,
         preferences: ProviderPreferences
     ) async throws -> TranslationResponse {
+        guard let credential else {
+            throw URLError(.userAuthenticationRequired)
+        }
         _ = preferences
         let targetLanguage = try targetLanguageResolver.resolve(request.targetLanguage, for: descriptor.id)
         var urlRequest = URLRequest(url: credential.apiKey.hasSuffix(":fx") ? freeEndpoint : proEndpoint)

--- a/GlobalTranslator/Services/Providers/Google/GoogleCloudTranslationProvider.swift
+++ b/GlobalTranslator/Services/Providers/Google/GoogleCloudTranslationProvider.swift
@@ -6,6 +6,7 @@ struct GoogleCloudTranslationProvider: TranslationProvider {
         displayName: "Google Cloud",
         credentialLabel: "API key",
         credentialPlaceholder: "Google Cloud API key",
+        requiresStoredCredential: true,
         supportsCustomModel: false,
         defaultModel: nil
     )
@@ -26,9 +27,12 @@ struct GoogleCloudTranslationProvider: TranslationProvider {
 
     func translate(
         _ request: TranslationRequest,
-        credential: ProviderCredential,
+        credential: ProviderCredential?,
         preferences: ProviderPreferences
     ) async throws -> TranslationResponse {
+        guard let credential else {
+            throw URLError(.userAuthenticationRequired)
+        }
         _ = preferences
         let targetLanguage = try targetLanguageResolver.resolve(request.targetLanguage, for: descriptor.id)
         guard var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {

--- a/GlobalTranslator/Services/Providers/OpenAI/OpenAIProvider.swift
+++ b/GlobalTranslator/Services/Providers/OpenAI/OpenAIProvider.swift
@@ -6,6 +6,7 @@ struct OpenAIProvider: TranslationProvider {
         displayName: "OpenAI",
         credentialLabel: "API key",
         credentialPlaceholder: "OpenAI API key",
+        requiresStoredCredential: true,
         supportsCustomModel: true,
         defaultModel: "gpt-4.1-mini"
     )
@@ -23,9 +24,12 @@ struct OpenAIProvider: TranslationProvider {
 
     func translate(
         _ request: TranslationRequest,
-        credential: ProviderCredential,
+        credential: ProviderCredential?,
         preferences: ProviderPreferences
     ) async throws -> TranslationResponse {
+        guard let credential else {
+            throw URLError(.userAuthenticationRequired)
+        }
         guard let model = preferences.model ?? descriptor.defaultModel else {
             throw URLError(.userAuthenticationRequired)
         }

--- a/GlobalTranslator/Services/Providers/ProviderRegistry.swift
+++ b/GlobalTranslator/Services/Providers/ProviderRegistry.swift
@@ -14,7 +14,7 @@ enum ProviderRegistryError: LocalizedError {
 struct ProviderRegistry: Sendable {
     private let providers: [String: any TranslationProvider]
 
-    init(providers: [any TranslationProvider] = [OpenAIProvider(), DeepLProvider(), GoogleCloudTranslationProvider()]) {
+    init(providers: [any TranslationProvider] = [OpenAIProvider(), DeepLProvider(), GoogleCloudTranslationProvider(), CopilotCLIProvider()]) {
         self.providers = Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0) })
     }
 
@@ -31,6 +31,8 @@ struct ProviderRegistry: Sendable {
     }
 
     var availableProviders: [ProviderDescriptor] {
-        providers.values.map(\.descriptor).sorted { $0.id < $1.id }
+        providers.values.map(\.descriptor).sorted {
+            $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
     }
 }

--- a/GlobalTranslator/Services/Providers/TranslationProvider.swift
+++ b/GlobalTranslator/Services/Providers/TranslationProvider.swift
@@ -5,6 +5,7 @@ struct ProviderDescriptor: Equatable, Sendable, Identifiable {
     let displayName: String
     let credentialLabel: String
     let credentialPlaceholder: String
+    let requiresStoredCredential: Bool
     let supportsCustomModel: Bool
     let defaultModel: String?
 }
@@ -23,7 +24,7 @@ protocol TranslationProvider: Sendable {
     var descriptor: ProviderDescriptor { get }
     func translate(
         _ request: TranslationRequest,
-        credential: ProviderCredential,
+        credential: ProviderCredential?,
         preferences: ProviderPreferences
     ) async throws -> TranslationResponse
 }

--- a/GlobalTranslator/Services/Support/SupportProtocols.swift
+++ b/GlobalTranslator/Services/Support/SupportProtocols.swift
@@ -26,7 +26,11 @@ protocol FileManaging: Sendable {
     func fileExists(atPath path: String) -> Bool
 }
 
-extension FileManager: FileManaging {}
+struct DefaultFileManager: FileManaging {
+    func fileExists(atPath path: String) -> Bool {
+        FileManager.default.fileExists(atPath: path)
+    }
+}
 
 protocol ClipboardWriting {
     func copy(_ string: String)

--- a/GlobalTranslator/Services/Support/SupportProtocols.swift
+++ b/GlobalTranslator/Services/Support/SupportProtocols.swift
@@ -22,6 +22,12 @@ protocol SecretStoring {
     func writeSecret(_ value: String, for key: String) throws
 }
 
+protocol FileManaging: Sendable {
+    func fileExists(atPath path: String) -> Bool
+}
+
+extension FileManager: FileManaging {}
+
 protocol ClipboardWriting {
     func copy(_ string: String)
 }
@@ -63,3 +69,88 @@ protocol HTTPClient: Sendable {
 }
 
 extension URLSession: HTTPClient {}
+
+struct CommandInvocation: Sendable {
+    let executableURL: URL
+    let arguments: [String]
+    let workingDirectoryURL: URL?
+    let environment: [String: String]
+    let timeout: TimeInterval
+}
+
+struct CommandResult: Sendable {
+    let stdout: String
+    let stderr: String
+    let exitCode: Int32
+}
+
+protocol CommandRunning: Sendable {
+    func run(_ invocation: CommandInvocation) async throws -> CommandResult
+}
+
+enum CommandRunnerError: LocalizedError {
+    case timedOut(command: String)
+    case failedToLaunch(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .timedOut(command):
+            return "The command timed out: \(command)"
+        case let .failedToLaunch(message):
+            return message
+        }
+    }
+}
+
+struct ProcessCommandRunner: CommandRunning {
+    func run(_ invocation: CommandInvocation) async throws -> CommandResult {
+        try await Task.detached(priority: nil) {
+            try runSynchronously(invocation)
+        }.value
+    }
+
+    private func runSynchronously(_ invocation: CommandInvocation) throws -> CommandResult {
+        let process = Process()
+        process.executableURL = invocation.executableURL
+        process.arguments = invocation.arguments
+        if let workingDirectoryURL = invocation.workingDirectoryURL {
+            process.currentDirectoryURL = workingDirectoryURL
+        }
+        if !invocation.environment.isEmpty {
+            process.environment = invocation.environment
+        }
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            finished.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            throw CommandRunnerError.failedToLaunch(error.localizedDescription)
+        }
+
+        if finished.wait(timeout: .now() + invocation.timeout) == .timedOut {
+            process.terminate()
+            _ = finished.wait(timeout: .now() + 1)
+            throw CommandRunnerError.timedOut(
+                command: ([invocation.executableURL.path] + invocation.arguments).joined(separator: " ")
+            )
+        }
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+        return CommandResult(
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? "",
+            exitCode: process.terminationStatus
+        )
+    }
+}

--- a/GlobalTranslator/Services/Translation/TranslationQueue.swift
+++ b/GlobalTranslator/Services/Translation/TranslationQueue.swift
@@ -77,22 +77,21 @@ actor TranslationQueue {
     }
 
     private func process(_ job: QueuedJob) async -> TranslationJobStatus {
-        guard let credential = job.credential else {
-            await notificationCenter.notify(
-                title: "Missing API key",
-                body: "Add an API key before running translations."
-            )
-            return .failed
-        }
-
         do {
             let provider = try providerRegistry.provider(for: job.settings.defaultProvider)
+            if provider.descriptor.requiresStoredCredential, job.credential == nil {
+                await notificationCenter.notify(
+                    title: "Missing API key",
+                    body: "Add an API key before running translations."
+                )
+                return .failed
+            }
             let response = try await provider.translate(
                 TranslationRequest(
                     text: job.selection.selectedText,
                     targetLanguage: job.settings.targetLanguage
                 ),
-                credential: credential,
+                credential: job.credential,
                 preferences: job.settings.preferences(for: job.settings.defaultProvider)
             )
             let outcome = await MainActor.run {

--- a/GlobalTranslatorTests/Contracts/CopilotCLIProviderTests.swift
+++ b/GlobalTranslatorTests/Contracts/CopilotCLIProviderTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import GlobalTranslatorApp
+
+final class CopilotCLIProviderTests: XCTestCase {
+    func testBuildsExpectedCommandAndParsesTrimmedStdout() async throws {
+        let runner = RecordingCommandRunner(
+            result: CommandResult(
+                stdout: " bonjour le monde \n",
+                stderr: "",
+                exitCode: 0
+            )
+        )
+        let provider = CopilotCLIProvider(
+            commandRunner: runner,
+            executableLocator: StubExecutableLocator(executable: URL(fileURLWithPath: "/opt/homebrew/bin/copilot")),
+            workingDirectory: URL(fileURLWithPath: "/tmp/global-translator-copilot")
+        )
+
+        let response = try await provider.translate(
+            TranslationRequest(text: "hello world", targetLanguage: "French"),
+            credential: nil,
+            preferences: ProviderPreferences(model: "gpt-5")
+        )
+        let maybeInvocation = await runner.firstInvocation()
+        let invocation = try XCTUnwrap(maybeInvocation)
+
+        XCTAssertEqual(response.translatedText, "bonjour le monde")
+        XCTAssertEqual(invocation.executableURL.path, "/opt/homebrew/bin/copilot")
+        XCTAssertEqual(try XCTUnwrap(invocation.workingDirectoryURL).path, "/tmp/global-translator-copilot")
+        XCTAssertTrue(invocation.arguments.contains("-p"))
+        XCTAssertTrue(invocation.arguments.contains("-s"))
+        XCTAssertTrue(invocation.arguments.contains("--allow-all-tools"))
+        XCTAssertTrue(invocation.arguments.contains("--disable-builtin-mcps"))
+        XCTAssertTrue(invocation.arguments.contains("--no-custom-instructions"))
+        XCTAssertTrue(invocation.arguments.contains("--no-auto-update"))
+        XCTAssertTrue(invocation.arguments.contains("--model"))
+        XCTAssertTrue(invocation.arguments.contains("gpt-5"))
+        XCTAssertTrue(invocation.arguments.contains("--excluded-tools"))
+        XCTAssertTrue(invocation.arguments.contains("read"))
+        XCTAssertTrue(invocation.arguments.contains("write"))
+        XCTAssertTrue(invocation.arguments.contains("shell"))
+        XCTAssertTrue(invocation.arguments.contains("url"))
+        XCTAssertTrue(invocation.arguments.contains("memory"))
+        XCTAssertTrue(invocation.arguments.joined(separator: " ").contains("Return only the translated text"))
+    }
+
+    func testThrowsHelpfulErrorWhenExecutableIsMissing() async {
+        let provider = CopilotCLIProvider(
+            commandRunner: RecordingCommandRunner(
+                result: CommandResult(stdout: "", stderr: "", exitCode: 0)
+            ),
+            executableLocator: StubExecutableLocator(executable: nil),
+            workingDirectory: URL(fileURLWithPath: "/tmp/global-translator-copilot")
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await provider.translate(
+                TranslationRequest(text: "hello", targetLanguage: "French"),
+                credential: nil,
+                preferences: .empty
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("Copilot CLI"))
+        }
+    }
+
+    func testThrowsWhenProcessReturnsEmptyOutput() async {
+        let runner = RecordingCommandRunner(
+            result: CommandResult(stdout: " \n", stderr: "", exitCode: 0)
+        )
+        let provider = CopilotCLIProvider(
+            commandRunner: runner,
+            executableLocator: StubExecutableLocator(executable: URL(fileURLWithPath: "/opt/homebrew/bin/copilot")),
+            workingDirectory: URL(fileURLWithPath: "/tmp/global-translator-copilot")
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await provider.translate(
+                TranslationRequest(text: "hello", targetLanguage: "French"),
+                credential: nil,
+                preferences: .empty
+            )
+        )
+    }
+
+    func testThrowsWhenProcessExitsNonZero() async {
+        let runner = RecordingCommandRunner(
+            result: CommandResult(stdout: "", stderr: "authentication required", exitCode: 1)
+        )
+        let provider = CopilotCLIProvider(
+            commandRunner: runner,
+            executableLocator: StubExecutableLocator(executable: URL(fileURLWithPath: "/opt/homebrew/bin/copilot")),
+            workingDirectory: URL(fileURLWithPath: "/tmp/global-translator-copilot")
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await provider.translate(
+                TranslationRequest(text: "hello", targetLanguage: "French"),
+                credential: nil,
+                preferences: .empty
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("authentication required"))
+        }
+    }
+}
+
+private actor RecordingCommandRunner: CommandRunning {
+    private(set) var invocations: [CommandInvocation] = []
+    let result: CommandResult
+
+    init(result: CommandResult) {
+        self.result = result
+    }
+
+    func run(_ invocation: CommandInvocation) async throws -> CommandResult {
+        invocations.append(invocation)
+        return result
+    }
+
+    func firstInvocation() -> CommandInvocation? {
+        invocations.first
+    }
+}
+
+private struct StubExecutableLocator: CopilotCLIExecutableLocating {
+    let executable: URL?
+
+    func findExecutable() -> URL? {
+        executable
+    }
+}
+
+private func XCTAssertThrowsErrorAsync(
+    _ expression: @autoclosure @escaping () async throws -> some Any,
+    _ errorHandler: ((Error) -> Void)? = nil,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected error to be thrown", file: file, line: line)
+    } catch {
+        errorHandler?(error)
+    }
+}

--- a/GlobalTranslatorTests/Unit/AppSettingsStoreTests.swift
+++ b/GlobalTranslatorTests/Unit/AppSettingsStoreTests.swift
@@ -7,7 +7,7 @@ final class AppSettingsStoreTests: XCTestCase {
         let store = AppSettingsStore(keyValueStore: InMemoryKeyValueStore())
 
         XCTAssertEqual(store.settings.targetLanguage, "English")
-        XCTAssertEqual(store.settings.defaultProvider, "openai")
+        XCTAssertEqual(store.settings.defaultProvider, "copilot")
         XCTAssertEqual(store.settings.hotkey, .commandShiftT)
         XCTAssertTrue(store.settings.recentJobs.isEmpty)
     }

--- a/GlobalTranslatorTests/Unit/CopilotCLIExecutableLocatorTests.swift
+++ b/GlobalTranslatorTests/Unit/CopilotCLIExecutableLocatorTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import GlobalTranslatorApp
+
+final class CopilotCLIExecutableLocatorTests: XCTestCase {
+    func testPrefersKnownMacOSInstallLocationsBeforePATHEntries() {
+        let locator = CopilotCLIExecutableLocator(
+            fileManager: StubFileManager(
+                existingPaths: [
+                    "/opt/homebrew/bin/copilot",
+                    "/usr/local/bin/copilot",
+                    "/custom/bin/copilot",
+                ]
+            ),
+            environment: ["PATH": "/custom/bin:/usr/bin"]
+        )
+
+        XCTAssertEqual(locator.findExecutable()?.path, "/opt/homebrew/bin/copilot")
+    }
+
+    func testFallsBackToPATHWhenKnownLocationsAreMissing() {
+        let locator = CopilotCLIExecutableLocator(
+            fileManager: StubFileManager(existingPaths: ["/custom/bin/copilot"]),
+            environment: ["PATH": "/custom/bin:/usr/bin"]
+        )
+
+        XCTAssertEqual(locator.findExecutable()?.path, "/custom/bin/copilot")
+    }
+
+    func testReturnsNilWhenExecutableCannotBeFound() {
+        let locator = CopilotCLIExecutableLocator(
+            fileManager: StubFileManager(existingPaths: []),
+            environment: ["PATH": "/custom/bin:/usr/bin"]
+        )
+
+        XCTAssertNil(locator.findExecutable())
+    }
+}
+
+private struct StubFileManager: FileManaging {
+    let existingPaths: Set<String>
+
+    func fileExists(atPath path: String) -> Bool {
+        existingPaths.contains(path)
+    }
+}

--- a/GlobalTranslatorTests/Unit/ProviderRegistryTests.swift
+++ b/GlobalTranslatorTests/Unit/ProviderRegistryTests.swift
@@ -6,24 +6,34 @@ final class ProviderRegistryTests: XCTestCase {
         let registry = ProviderRegistry()
         let providers = registry.availableProviders
 
-        XCTAssertEqual(providers.map(\.id), ["deepl", "google", "openai"])
+        XCTAssertEqual(providers.map(\.id), ["deepl", "copilot", "google", "openai"])
 
         let deepl = try XCTUnwrap(providers.first(where: { $0.id == "deepl" }))
         XCTAssertEqual(deepl.displayName, "DeepL")
         XCTAssertEqual(deepl.credentialLabel, "API key")
         XCTAssertEqual(deepl.credentialPlaceholder, "DeepL API key")
+        XCTAssertTrue(deepl.requiresStoredCredential)
         XCTAssertFalse(deepl.supportsCustomModel)
         XCTAssertNil(deepl.defaultModel)
+
+        let copilot = try XCTUnwrap(providers.first(where: { $0.id == "copilot" }))
+        XCTAssertEqual(copilot.displayName, "GitHub Copilot")
+        XCTAssertEqual(copilot.credentialPlaceholder, "")
+        XCTAssertFalse(copilot.requiresStoredCredential)
+        XCTAssertTrue(copilot.supportsCustomModel)
+        XCTAssertNil(copilot.defaultModel)
 
         let google = try XCTUnwrap(providers.first(where: { $0.id == "google" }))
         XCTAssertEqual(google.displayName, "Google Cloud")
         XCTAssertEqual(google.credentialPlaceholder, "Google Cloud API key")
+        XCTAssertTrue(google.requiresStoredCredential)
         XCTAssertFalse(google.supportsCustomModel)
         XCTAssertNil(google.defaultModel)
 
         let openAI = try XCTUnwrap(providers.first(where: { $0.id == "openai" }))
         XCTAssertEqual(openAI.displayName, "OpenAI")
         XCTAssertEqual(openAI.credentialPlaceholder, "OpenAI API key")
+        XCTAssertTrue(openAI.requiresStoredCredential)
         XCTAssertTrue(openAI.supportsCustomModel)
         XCTAssertEqual(openAI.defaultModel, "gpt-4.1-mini")
     }

--- a/GlobalTranslatorTests/Unit/TranslationQueueTests.swift
+++ b/GlobalTranslatorTests/Unit/TranslationQueueTests.swift
@@ -12,7 +12,7 @@ final class TranslationQueueTests: XCTestCase {
             writebackService: writebackService,
             notificationCenter: NoopUserNotificationCenter()
         )
-        let settings = AppSettings()
+        let settings = AppSettings(defaultProvider: "openai")
         let selectionA = CapturedSelection(
             frontmostBundleID: "com.apple.TextEdit",
             selectedText: "hello",
@@ -45,6 +45,37 @@ final class TranslationQueueTests: XCTestCase {
         XCTAssertEqual(snapshots.map(\.status), [.succeeded, .succeeded])
         XCTAssertEqual(recordedTexts, ["hello", "world"])
     }
+
+    func testProcessesCredentiallessProvidersWithoutFailingPreflight() async throws {
+        let provider = FakeCredentiallessProvider()
+        let registry = ProviderRegistry(providers: [provider])
+        let clipboard = ClipboardSpy()
+        let writebackService = await MainActor.run { WritebackService(clipboard: clipboard) }
+        let queue = TranslationQueue(
+            providerRegistry: registry,
+            writebackService: writebackService,
+            notificationCenter: NoopUserNotificationCenter()
+        )
+        let settings = AppSettings(defaultProvider: "copilot")
+        let selection = CapturedSelection(
+            frontmostBundleID: "com.apple.TextEdit",
+            selectedText: "hello",
+            selectedRange: NSRange(location: 0, length: 5),
+            capturedAt: Date(),
+            writebackTarget: RecordingWritebackTarget()
+        )
+
+        _ = await queue.enqueue(
+            selection: selection,
+            settings: settings,
+            credential: nil
+        )
+        let snapshots = await queue.waitUntilIdle()
+        let recordedTexts = await provider.recordedTexts
+
+        XCTAssertEqual(snapshots.map(\.status), [.succeeded])
+        XCTAssertEqual(recordedTexts, ["hello"])
+    }
 }
 
 private actor FakeProvider: TranslationProvider {
@@ -53,12 +84,32 @@ private actor FakeProvider: TranslationProvider {
         displayName: "OpenAI",
         credentialLabel: "API key",
         credentialPlaceholder: "OpenAI API key",
+        requiresStoredCredential: true,
         supportsCustomModel: true,
         defaultModel: "gpt-4.1-mini"
     )
     private(set) var recordedTexts: [String] = []
 
-    func translate(_ request: TranslationRequest, credential: ProviderCredential, preferences: ProviderPreferences) async throws -> TranslationResponse {
+    func translate(_ request: TranslationRequest, credential: ProviderCredential?, preferences: ProviderPreferences) async throws -> TranslationResponse {
+        recordedTexts.append(request.text)
+        return TranslationResponse(translatedText: "translated-\(request.text)", detectedSourceLanguage: "auto")
+    }
+}
+
+private actor FakeCredentiallessProvider: TranslationProvider {
+    nonisolated let descriptor = ProviderDescriptor(
+        id: "copilot",
+        displayName: "GitHub Copilot",
+        credentialLabel: "",
+        credentialPlaceholder: "",
+        requiresStoredCredential: false,
+        supportsCustomModel: true,
+        defaultModel: nil
+    )
+    private(set) var recordedTexts: [String] = []
+
+    func translate(_ request: TranslationRequest, credential: ProviderCredential?, preferences: ProviderPreferences) async throws -> TranslationResponse {
+        XCTAssertNil(credential)
         recordedTexts.append(request.text)
         return TranslationResponse(translatedText: "translated-\(request.text)", detectedSourceLanguage: "auto")
     }

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A native macOS menu bar translator that captures selected editable text, transla
 
 ## Features
 
+- GitHub Copilot CLI as the default local provider, without storing an API key
 - Global hotkey trigger with a menu bar-only app shell
 - Accessibility-based selected-text capture
 - Background serial translation queue
 - Direct writeback to the original selection when the source element is still writable
 - Safe fallback to notification plus clipboard when writeback fails
-- Built-in OpenAI, DeepL, and Google Cloud Translation Basic v2 adapters, with a provider registry for future adapters
+- Built-in GitHub Copilot CLI, OpenAI, DeepL, and Google Cloud Translation Basic v2 adapters, with a provider registry for future adapters
 
 ## Project Layout
 
@@ -31,6 +32,13 @@ open GlobalTranslator.xcodeproj
 ## Setup Notes
 
 1. Grant Accessibility permission to `GlobalTranslator`.
-2. Save a provider API key in Settings.
-3. Pick a target language using a common language name or code, then choose a preferred hotkey.
-4. Select editable text in another app and press the hotkey.
+2. Install `copilot` locally and sign in once from Terminal if you want to use the default provider.
+3. Optionally switch to `OpenAI`, `DeepL`, or `Google Cloud` in Settings and save the corresponding API key.
+4. Pick a target language using a common language name or code, then choose a preferred hotkey.
+5. Select editable text in another app and press the hotkey.
+
+## Copilot CLI Notes
+
+- `GitHub Copilot` is the default provider for new installs.
+- The app uses your existing local `copilot` CLI session and does not store a Copilot API key.
+- This integration uses single-shot CLI prompts only. It does not use ACP, and it does not modify `~/.copilot` or load repo custom instructions.


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI as a first-class translation provider with executable discovery and subprocess execution
- allow providers to opt out of stored API credentials, and make Copilot the default provider for new installs
- update settings, onboarding, README, and tests for provider-aware setup and Copilot-specific failure paths

## Verification
- `swift test`
- `xcodebuild test -project GlobalTranslator.xcodeproj -scheme GlobalTranslator -destination 'platform=macOS'`\n